### PR TITLE
BREAKING: imported config-file should take priority over provided configs

### DIFF
--- a/src/module-config/module-config.test.ts
+++ b/src/module-config/module-config.test.ts
@@ -370,7 +370,7 @@ describe("resolveImportMapConfig", () => {
     expect(config.foo).toBe("bar");
   });
 
-  it("always puts config file from import map at lowest priority", async () => {
+  it("always puts config file from import map at highest priority", async () => {
     Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
     const importedConfig = importableConfig({ "foo-module": { foo: "bar" } });
     (<any>window).System.resolve.mockReturnValue(true);
@@ -378,7 +378,7 @@ describe("resolveImportMapConfig", () => {
     const providedConfig = { "foo-module": { foo: "baz" } };
     Config.provide(providedConfig);
     const config = await Config.getConfig("foo-module");
-    expect(config.foo).toBe("baz");
+    expect(config.foo).toBe("bar");
   });
 
   it("does not 404 when no config file is in the import map", () => {

--- a/src/module-config/module-config.ts
+++ b/src/module-config/module-config.ts
@@ -76,7 +76,7 @@ async function getImportMapConfigFile(): Promise<void> {
   if (importMapConfigExists) {
     try {
       const configFileModule = await System.import("config-file");
-      configs.unshift(configFileModule.default);
+      configs.push(configFileModule.default);
     } catch (e) {
       throw Error("Problem importing config-file: " + e);
     }


### PR DESCRIPTION
This is a breaking change.

The idea is that configs loaded as `config-file` in the import map should take priority over configs provided in the root config.

The reason is that the former are easier to change, override, etc, and therefore are more "dynamic", and therefore it makes more sense to have them override the latter.