### PR TITLE
Fix navigate to handle SPA routes correctly

### DIFF
--- a/src/navigation/navigate.test.ts
+++ b/src/navigation/navigate.test.ts
@@ -46,19 +46,19 @@ describe("navigate", () => {
 
   it("uses single-spa navigateToUrl to navigate to SPA path literal", () => {
     navigate({ to: "/openmrs/spa/foo/page" });
-    expect(navigateToUrl).toHaveBeenCalledWith("/foo/page");
+    expect(navigateToUrl).toHaveBeenCalledWith("/openmrs/spa/foo/page");
     expect(window.location.assign).not.toHaveBeenCalled();
   });
 
   it("uses single-spa navigateToUrl to navigate to interpolated SPA path", () => {
     navigate({ to: "${openmrsSpaBase}/bar/page" });
-    expect(navigateToUrl).toHaveBeenCalledWith("/bar/page");
+    expect(navigateToUrl).toHaveBeenCalledWith("/openmrs/spa/bar/page");
     expect(window.location.assign).not.toHaveBeenCalled();
   });
 
   it("tolerates an extra inital slash", () => {
     navigate({ to: "/${openmrsSpaBase}/baz/page" });
-    expect(navigateToUrl).toHaveBeenCalledWith("/baz/page");
+    expect(navigateToUrl).toHaveBeenCalledWith("/openmrs/spa/baz/page");
     expect(window.location.assign).not.toHaveBeenCalled();
   });
 });

--- a/src/navigation/navigate.ts
+++ b/src/navigation/navigate.ts
@@ -26,12 +26,13 @@ export function navigate({ to }: NavigateOptions): void {
   const target = interpolateUrl(to);
   const isSpaPath = target.startsWith(openmrsSpaBase);
   if (isSpaPath) {
-    const spaTarget = target.replace(new RegExp("^" + openmrsSpaBase), "");
-    navigateToUrl(spaTarget);
+    navigateToUrl(target);
   } else {
     window.location.assign(target);
   }
 }
+
+console.log("yo!!!");
 
 type NavigateOptions = {
   to: string;

--- a/src/navigation/navigate.ts
+++ b/src/navigation/navigate.ts
@@ -32,8 +32,6 @@ export function navigate({ to }: NavigateOptions): void {
   }
 }
 
-console.log("yo!!!");
-
 type NavigateOptions = {
   to: string;
 };


### PR DESCRIPTION
Whoops! Apparently single-spa navigateToUrl expects the full path, even for intra-SPA links.

This time everything is tested and working in esm-home.