### PR TITLE
Add devDefault keyword, toggled on window.openmrsConfigUseDevDefaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ ___
 
 ▸ **defineConfigSchema**(`moduleName`: string, `schema`: ConfigSchema): *void*
 
-*Defined in [module-config/module-config.ts:13](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L13)*
+*Defined in [module-config/module-config.ts:21](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L21)*
 
 **Parameters:**
 
@@ -504,7 +504,7 @@ ___
 
 ▸ **getConfig**(`moduleName`: string): *Promise‹ConfigObject›*
 
-*Defined in [module-config/module-config.ts:22](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L22)*
+*Defined in [module-config/module-config.ts:30](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L30)*
 
 **Parameters:**
 
@@ -520,7 +520,7 @@ ___
 
 ▸ **processConfig**(`schema`: ConfigSchema, `providedConfig`: ConfigObject, `keyPathContext`: string): *any*
 
-*Defined in [module-config/module-config.ts:35](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L35)*
+*Defined in [module-config/module-config.ts:43](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L43)*
 
 Validate and interpolate defaults for `providedConfig` according to `schema`
 
@@ -540,7 +540,7 @@ ___
 
 ▸ **provide**(`config`: Config): *void*
 
-*Defined in [module-config/module-config.ts:18](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L18)*
+*Defined in [module-config/module-config.ts:26](https://github.com/openmrs/openmrs-esm-module-config/blob/master/src/module-config/module-config.ts#L26)*
 
 **Parameters:**
 

--- a/src/module-config/module-config.test.ts
+++ b/src/module-config/module-config.test.ts
@@ -90,6 +90,23 @@ describe("getConfig", () => {
     expect(config.foo).toBe("qux");
   });
 
+  it("returns devDefault values when defined when turned on", async () => {
+    window.openmrsConfigUseDevDefaults = true;
+    Config.defineConfigSchema("testmod", {
+      foo: {
+        default: "qux"
+      },
+      bar: {
+        default: "pub",
+        devDefault: "barcade"
+      }
+    });
+    const config = await Config.getConfig("testmod");
+    expect(config.foo).toBe("qux");
+    expect(config.bar).toBe("barcade");
+    delete window.openmrsConfigUseDevDefaults;
+  });
+
   it("logs an error if config values not defined in the schema", async () => {
     Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
     Config.provide({ "foo-module": { bar: "baz" } });

--- a/src/module-config/module-config.ts
+++ b/src/module-config/module-config.ts
@@ -1,5 +1,13 @@
 import * as R from "ramda";
 
+declare global {
+  interface Window {
+    openmrsConfigUseDevDefaults: boolean;
+  }
+}
+window.openmrsConfigUseDevDefaults =
+  window.openmrsConfigUseDevDefaults || false;
+
 // The configurations that have been provided
 const configs: Config[] = [];
 
@@ -249,9 +257,12 @@ const setDefaults = (schema, config) => {
   for (let key of Object.keys(schema)) {
     if (schema[key].hasOwnProperty("default")) {
       // We assume that schema[key] defines a config value, since it has
-      // a property "default."
+      // a property `default`.
       if (!config.hasOwnProperty(key)) {
-        config[key] = schema[key]["default"];
+        const devDefault = schema[key]["devDefault"] || schema[key]["default"];
+        config[key] = window.openmrsConfigUseDevDefaults
+          ? devDefault
+          : schema[key]["default"];
       }
       // We also check if it is an array with object elements, in which case we recurse
       if (


### PR DESCRIPTION
This allows modules can specify a `devDefault` for items in their config schema that is toggled based on a `window` property. This allows those elements to work as feature toggles. Then we can add a switch to DevTools that turns all those feature toggles on or off.