### PR TITLE
Schema validation should allow arrayElements to have keys without defaults

### DIFF
--- a/src/module-config/module-config.test.ts
+++ b/src/module-config/module-config.test.ts
@@ -84,6 +84,29 @@ describe("defineConfigSchema", () => {
       expect.stringMatching(/mod-mod.*foo\.bar[\s\S]*default/)
     );
   });
+
+  it("logs an error if any key is empty", () => {
+    const schema = {
+      foo: { bar: {} }
+    };
+    Config.defineConfigSchema("mod-mod", schema);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringMatching(/mod-mod.*foo\.bar[\s\S]*default/)
+    );
+  });
+
+  it("does not log an error if an arrayElement object has a key without a default", () => {
+    const schema = {
+      foo: {
+        default: [],
+        arrayElements: {
+          bar: {}
+        }
+      }
+    };
+    Config.defineConfigSchema("mod-mod", schema);
+    expect(console.error).not.toHaveBeenCalled();
+  });
 });
 
 describe("getConfig", () => {

--- a/src/module-config/module-config.ts
+++ b/src/module-config/module-config.ts
@@ -170,7 +170,8 @@ function validateConfigSchema(
             "arrayElements",
             "dictionaryElements"
           ].includes(k)
-        )
+        ) &&
+        !keyPath.includes(".arrayElements")
       ) {
         console.error(
           `${moduleName} has bad config schema definition for key '${thisKeyPath}'. ${updateMessage}.` +


### PR DESCRIPTION
Fixing this situation (the errors are erroneous):

![Screenshot from 2020-08-28 21-35-47](https://user-images.githubusercontent.com/1031876/91628629-75ccf300-e976-11ea-91a5-bd3fe81ac92d.png)
